### PR TITLE
use targetClass in dataset generator

### DIFF
--- a/shacl-ts-generator/src/generator/dataset-generator.ts
+++ b/shacl-ts-generator/src/generator/dataset-generator.ts
@@ -34,14 +34,19 @@ export class DatasetGenerator {
       const datasetFilePath = path.join(output, `${className}.ts`);
 
       const imports = new Set<string>();
-      const getters = nodeShapes
-        .map(shape => {
-          const methodName = shape.codeIdentifier[0].toLowerCase() + shape.codeIdentifier.slice(1);
-          imports.add(`import { ${shape.codeIdentifier} } from "./${shape.codeIdentifier}.js";`);
 
-          // Use full IRI as NamedNode value to avoid import issues in dataset class
+      const getters = nodeShapes
+        .filter(shape => shape.targetClass) // only include shapes with targetClass
+        .map(shape => {
+          const methodName =
+            shape.codeIdentifier[0].toLowerCase() + shape.codeIdentifier.slice(1);
+
+          imports.add(
+            `import { ${shape.codeIdentifier} } from "./${shape.codeIdentifier}.js";`
+          );
+
           return `  get ${methodName}() {
-    return this.instancesOf("${shape.value}", ${shape.codeIdentifier});
+    return this.instancesOf("${shape.targetClass}", ${shape.codeIdentifier});
   }`;
         })
         .join("\n\n");

--- a/shacl-ts-generator/src/model/shacl-model.ts
+++ b/shacl-ts-generator/src/model/shacl-model.ts
@@ -149,6 +149,9 @@ export class ShapeModel extends TermWrapper {
     );
   }
 
+  get targetClass(): string | undefined {
+    return OptionalFrom.subjectPredicate(this, SHACL.targetClass, NamedNodeAs.string);
+  }
   
   get extends(): string[] {
   

--- a/shacl-ts-generator/src/vocab/shacl.ts
+++ b/shacl-ts-generator/src/vocab/shacl.ts
@@ -13,4 +13,5 @@ export const SHACL = {
   inversePath: "http://www.w3.org/ns/shacl#inversePath",
   in: "http://www.w3.org/ns/shacl#in",
   and: "http://www.w3.org/ns/shacl#and",
+  targetClass: "http://www.w3.org/ns/shacl#targetClass",
 } as const;


### PR DESCRIPTION
update to user sh:targetClass in Dataset output file - previously using nodeshape id incorrectly eg 

```
import { DatasetWrapper } from "@rdfjs/wrapper";
import { Bookmark } from "./Bookmark.js";
import { BookmarkAnnotea } from "./BookmarkAnnotea.js";
import { BookmarkTopic } from "./BookmarkTopic.js";

export class BookmarkDataset extends DatasetWrapper {
  get bookmark() {
    return this.instancesOf("http://www.w3.org/2002/01/bookmark#Bookmark", Bookmark);
  }

  get bookmarkAnnotea() {
    return this.instancesOf("http://www.w3.org/2002/01/bookmark#Bookmark", BookmarkAnnotea);
  }

  get bookmarkTopic() {
    return this.instancesOf("http://www.w3.org/2002/01/bookmark#Topic", BookmarkTopic);
  }
}


```